### PR TITLE
fix missing relay messages

### DIFF
--- a/scripts/plugins/ChatSounds.as
+++ b/scripts/plugins/ChatSounds.as
@@ -130,7 +130,7 @@ HookReturnCode ClientSay(SayParameters@ pParams) {
         if ( pArguments.ArgC() == 1 )
           pParams.ShouldHide = true;
 
-        return HOOK_HANDLED;
+        return pArguments.ArgC() == 1 ? HOOK_HANDLED : HOOK_CONTINUE;
       }
       else {
         if (soundArg == 'medic' || soundArg == 'meedic') {


### PR DESCRIPTION
messages aren't showing in the relay if the first word is a chatsound and the cooldown isn't finished.